### PR TITLE
Fix des groupes dont on est owner qui n'apparaissent pas

### DIFF
--- a/nsarchive/__init__.py
+++ b/nsarchive/__init__.py
@@ -170,6 +170,7 @@ class EntityInstance:
 
         id = NSID(id)
         groups = self.fetch_entities({'_type': 'organization'}, {'members': id})
+        groups.extend(self.fetch_entities({'_type': 'organization', 'owner_id': id}))
         
         return groups
 


### PR DESCRIPTION
La fonction scannait les membres mais pas le propriétaire de chaque groupe.